### PR TITLE
Added `r` to indicate it's a raw string. Python 3.14 gives a warning

### DIFF
--- a/src/mkdocs_badges/parser.py
+++ b/src/mkdocs_badges/parser.py
@@ -20,7 +20,7 @@ class SplitPart(NamedTuple):
 # Optional whitespace, optional alignment, at least three dashes, optional alignment, optional whitespace
 # Update from #4: It seems to be possible to just use a single dash
 TABLE_CELL_REGEX = r"\s*:?-+:?\s*"
-TABLE_HEADER_REGEX = re.compile(r"^\s*\|?"+ TABLE_CELL_REGEX + r"(\|" + TABLE_CELL_REGEX + ")+\|?\s*$")
+TABLE_HEADER_REGEX = re.compile(r"^\s*\|?"+ TABLE_CELL_REGEX + r"(\|" + TABLE_CELL_REGEX + r")+\|?\s*$")
 
 CLASS_ATTR_REGEX = re.compile(r"^(?:\.|(?:class:))(.*)$")
 COPY_ATTR_REGEX = re.compile(r"^c(?:opy)?:(.*)$")


### PR DESCRIPTION
With Python 3.14 you receive the following warning:
```
INFO    -  SyntaxWarning: "\|" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\|"? A raw string is also an option.
             File "/Users/stam0001/Development/hpcv/docs/services/.venv/lib/python3.14/site-packages/mkdocs_badges/install_badge.py", line 5, in <module>
               from .parser import ParserResultEntry
             File "/Users/stam0001/Development/hpcv/docs/services/.venv/lib/python3.14/site-packages/mkdocs_badges/parser.py", line 23, in
               TABLE_HEADER_REGEX = re.compile(r"^\s*\|?"+ TABLE_CELL_REGEX + r"(\|" + TABLE_CELL_REGEX + ")+\|?\s*$")
```

Looking at the code, it was missing the `r` in the last block.